### PR TITLE
Verify the simple alternative orders of delivery

### DIFF
--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BaseFrom3To2TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BaseFrom3To2TeamsSolver.java
@@ -1,0 +1,68 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hashcode.Solver;
+import org.hashcode.practice2021.model.Delivery;
+import org.hashcode.practice2021.model.Pizza;
+import org.hashcode.practice2021.model.PizzeriaInput;
+import org.hashcode.practice2021.model.PizzeriaOutput;
+
+abstract class BaseFrom3To2TeamsSolver implements Solver<PizzeriaInput, PizzeriaOutput> {
+
+    private final PizzaSelector pizzaSelector;
+
+    protected BaseFrom3To2TeamsSolver(PizzaSelector pizzaSelector) {
+        this.pizzaSelector = pizzaSelector;
+    }
+
+    @Override
+    public PizzeriaOutput solve(PizzeriaInput inputData) {
+        List<Pizza> pizzas = inputData.getPizzas();
+        pizzas.sort(Comparator.comparing(Pizza::getNumberOfIngredients).reversed());
+        assert pizzas.get(0).getNumberOfIngredients() > pizzas.get(pizzas.size() - 1).getNumberOfIngredients();
+
+        List<Delivery> deliveries = chooseDeliveries(pizzas,
+                inputData.get4PersonsTeams(), inputData.get3PersonsTeams(), inputData.get2PersonsTeams());
+        return new PizzeriaOutput(deliveries);
+    }
+
+    private List<Delivery> chooseDeliveries(List<Pizza> pizzas, int teams4, int teams3, int teams2) {
+        List<Delivery> deliveries = new ArrayList<>();
+
+        while ((pizzas.size() >= 3 && (teams3 >= 1 || teams2 >= 1))
+                || (pizzas.size() >= 2 && teams2 >= 1)
+                || (pizzas.size() >= 4 && teams4 >= 1)) {
+            int teamSize;
+            if (teams3 >= 1 && pizzas.size() >= 3) {
+                teamSize = 3;
+                teams3 -= 1;
+            } else if (teams2 >= 1) {
+                teamSize = 2;
+                teams2 -= 1;
+            } else {
+                teamSize = 4;
+                teams4 -= 1;
+            }
+
+            List<Integer> chosenPizzas = new ArrayList<>(4);
+            Pizza firstPizza = pizzas.remove(0);
+            chosenPizzas.add(firstPizza.getId());
+            Set<String> chosenIngredients = new HashSet<>(firstPizza.getIngredients());
+
+            for (int t = teamSize - 1; t >= 1; t--) {
+                pizzaSelector.choosePizza(pizzas, chosenPizzas, chosenIngredients);
+            }
+            assert chosenPizzas.size() == teamSize;
+            Delivery delivery = new Delivery(teamSize, chosenIngredients.size(), chosenPizzas);
+            deliveries.add(delivery);
+        }
+        assert pizzas.size() < 2 || (teams4 + teams3 + teams2 == 0)
+                || (pizzas.size() == 2 && teams2 == 0) || (pizzas.size() == 4 && teams4 == 0);
+        return deliveries;
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BaseFrom3To4TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BaseFrom3To4TeamsSolver.java
@@ -1,0 +1,68 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hashcode.Solver;
+import org.hashcode.practice2021.model.Delivery;
+import org.hashcode.practice2021.model.Pizza;
+import org.hashcode.practice2021.model.PizzeriaInput;
+import org.hashcode.practice2021.model.PizzeriaOutput;
+
+abstract class BaseFrom3To4TeamsSolver implements Solver<PizzeriaInput, PizzeriaOutput> {
+
+    private final PizzaSelector pizzaSelector;
+
+    protected BaseFrom3To4TeamsSolver(PizzaSelector pizzaSelector) {
+        this.pizzaSelector = pizzaSelector;
+    }
+
+    @Override
+    public PizzeriaOutput solve(PizzeriaInput inputData) {
+        List<Pizza> pizzas = inputData.getPizzas();
+        pizzas.sort(Comparator.comparing(Pizza::getNumberOfIngredients).reversed());
+        assert pizzas.get(0).getNumberOfIngredients() > pizzas.get(pizzas.size() - 1).getNumberOfIngredients();
+
+        List<Delivery> deliveries = chooseDeliveries(pizzas,
+                inputData.get4PersonsTeams(), inputData.get3PersonsTeams(), inputData.get2PersonsTeams());
+        return new PizzeriaOutput(deliveries);
+    }
+
+    private List<Delivery> chooseDeliveries(List<Pizza> pizzas, int teams4, int teams3, int teams2) {
+        List<Delivery> deliveries = new ArrayList<>();
+
+        while ((pizzas.size() >= 3 && (teams3 >= 1 || teams2 >= 1))
+                || (pizzas.size() >= 4 && teams4 >= 1)
+                || (pizzas.size() >= 2 && teams2 >= 1)) {
+            int teamSize;
+            if (teams3 >= 1 && pizzas.size() >= 3) {
+                teamSize = 3;
+                teams3 -= 1;
+            } else if (teams4 >= 1 && pizzas.size() >= 4) {
+                teamSize = 4;
+                teams4 -= 1;
+            } else {
+                teamSize = 2;
+                teams2 -= 1;
+            }
+
+            List<Integer> chosenPizzas = new ArrayList<>(4);
+            Pizza firstPizza = pizzas.remove(0);
+            chosenPizzas.add(firstPizza.getId());
+            Set<String> chosenIngredients = new HashSet<>(firstPizza.getIngredients());
+
+            for (int t = teamSize - 1; t >= 1; t--) {
+                pizzaSelector.choosePizza(pizzas, chosenPizzas, chosenIngredients);
+            }
+            assert chosenPizzas.size() == teamSize;
+            Delivery delivery = new Delivery(teamSize, chosenIngredients.size(), chosenPizzas);
+            deliveries.add(delivery);
+        }
+        assert pizzas.size() < 2 || (teams4 + teams3 + teams2 == 0)
+                || (pizzas.size() == 2 && teams2 == 0) || (pizzas.size() == 4 && teams4 == 0);
+        return deliveries;
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BestBalanceFrom3To2TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BestBalanceFrom3To2TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class BestBalanceFrom3To2TeamsSolver extends BaseFrom3To2TeamsSolver {
+
+    public BestBalanceFrom3To2TeamsSolver() {
+        super(new BestBalancePizzaSelector());
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BestBalanceFrom3To4TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/BestBalanceFrom3To4TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class BestBalanceFrom3To4TeamsSolver extends BaseFrom3To4TeamsSolver {
+
+    public BestBalanceFrom3To4TeamsSolver() {
+        super(new BestBalancePizzaSelector());
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/LowestWasteFrom3To2TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/LowestWasteFrom3To2TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class LowestWasteFrom3To2TeamsSolver extends BaseFrom3To2TeamsSolver {
+
+    public LowestWasteFrom3To2TeamsSolver() {
+        super(new LowestWastePizzaSelector());
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/LowestWasteFrom3To4TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/LowestWasteFrom3To4TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class LowestWasteFrom3To4TeamsSolver extends BaseFrom3To4TeamsSolver {
+
+    public LowestWasteFrom3To4TeamsSolver() {
+        super(new LowestWastePizzaSelector());
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/MostNewIngredientsFrom3To2TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/MostNewIngredientsFrom3To2TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class MostNewIngredientsFrom3To2TeamsSolver extends BaseFrom3To2TeamsSolver {
+
+    public MostNewIngredientsFrom3To2TeamsSolver() {
+        super(new MostNewIngredientsPizzaSelector());
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/MostNewIngredientsFrom3To4TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/MostNewIngredientsFrom3To4TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class MostNewIngredientsFrom3To4TeamsSolver extends BaseFrom3To4TeamsSolver {
+
+    public MostNewIngredientsFrom3To4TeamsSolver() {
+        super(new MostNewIngredientsPizzaSelector());
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/NaiveFrom3To2TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/NaiveFrom3To2TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class NaiveFrom3To2TeamsSolver extends BaseFrom3To2TeamsSolver {
+
+    public NaiveFrom3To2TeamsSolver() {
+        super(new NaivePizzaSelector());
+    }
+}

--- a/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/NaiveFrom3To4TeamsSolver.java
+++ b/practice-2021/src/main/java/org/hashcode/practice2021/solvers/ingredients/NaiveFrom3To4TeamsSolver.java
@@ -1,0 +1,8 @@
+package org.hashcode.practice2021.solvers.ingredients;
+
+public class NaiveFrom3To4TeamsSolver extends BaseFrom3To4TeamsSolver {
+
+    public NaiveFrom3To4TeamsSolver() {
+        super(new NaivePizzaSelector());
+    }
+}


### PR DESCRIPTION
@luccap11 Following up our chats in regards to alternative ways to deliver pizzas, I have implemented the trivial alternatives, the ones staring from teams of 3 persons:
1. deliver to teams of 3, 2 and 4 (`BaseFrom3To2TeamsSolver`);
2. deliver to teams of 3, 4 and 2 (`BaseFrom3To4TeamsSolver`).

Unsurprisingly, overall there is no benefit in applying these delivery strategies. However, with these two new basic heuristics it is indeed possible to achieve the optimal solution for input A (see the updated [spreadsheet](https://docs.google.com/spreadsheets/d/1bPGYJM7xQHjEFhLrPpaiQ0pFT4BAI3KCD1KSWipLHNU/edit)).

These modifications are just a first, simple step towards the more sophisticated approach of "buckets" we discussed together. I'll try to implement it in the next few days.